### PR TITLE
Visibility timeout and acknowledge workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <jackson.version>2.14.2</jackson.version>
         <aws-sdk-sqs.version>1.12.406</aws-sdk-sqs.version>
         <slf4j.version>2.0.6</slf4j.version>
+        <junit.version>5.9.2</junit.version>
     </properties>
 
     <dependencyManagement>
@@ -73,6 +74,13 @@
                 <version>${jackson.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+           <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -133,7 +141,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -213,6 +226,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/com/mercateo/sqs/utils/message/handling/LongRunningMessageHandler.java
+++ b/src/main/java/com/mercateo/sqs/utils/message/handling/LongRunningMessageHandler.java
@@ -56,6 +56,8 @@ public class LongRunningMessageHandler<I, O> {
 
     private final Duration awaitShutDown;
 
+    private final int numberOfThreads;
+
     LongRunningMessageHandler(@NonNull ScheduledExecutorService timeoutExtensionExecutor,
             int maxNumberOfMessages, int numberOfThreads,
             @NonNull MessageHandlingRunnableFactory messageHandlingRunnableFactory,
@@ -78,10 +80,11 @@ public class LongRunningMessageHandler<I, O> {
         this.timeUntilVisibilityTimeoutExtension = timeUntilVisibilityTimeoutExtension;
         this.awaitShutDown = awaitShutDown;
         this.errorHandlingStrategy = errorHandlingStrategy;
+        this.numberOfThreads = numberOfThreads;
 
         messageProcessingExecutor = new ThreadPoolTaskExecutor();
-        messageProcessingExecutor.setMaxPoolSize(numberOfThreads);
         messageProcessingExecutor.setCorePoolSize(numberOfThreads);
+        messageProcessingExecutor.setMaxPoolSize(numberOfThreads);
         messageProcessingExecutor.setThreadNamePrefix(getClass().getSimpleName()+"-"+queue.getName().getId()+"-");
         /*
          * Since we only accept new messages if one slot in the messagesInProcessing-Set
@@ -155,6 +158,21 @@ public class LongRunningMessageHandler<I, O> {
         }
 
         messagesInProcessing.waitUntilAtLeastOneFree();
+    }
+
+    /** 
+     * Returns the number of threads that are currently not busy working on messages.
+     * <p>
+     * The method is intended as a workaround for message visibility extension 
+     * and message acknowledge errors, but can only be applied, when you have
+     * control over the messages listener (i.e. not using the Spring one) and
+     * you can actually use it.
+     * See https://github.com/Mercateo/sqs-utils/issues/16 for details
+     * 
+     * @return Number of threads that are currently not processing messages
+     */
+    public int getFreeWorkerCapacity() {
+        return numberOfThreads - messagesInProcessing.size();
     }
 
     private void scheduleNewMessageTask(@NonNull Message<I> message,

--- a/src/main/java/com/mercateo/sqs/utils/message/handling/LongRunningMessageHandler.java
+++ b/src/main/java/com/mercateo/sqs/utils/message/handling/LongRunningMessageHandler.java
@@ -172,7 +172,7 @@ public class LongRunningMessageHandler<I, O> {
      * @return Number of threads that are currently not processing messages
      */
     public int getFreeWorkerCapacity() {
-        return numberOfThreads - messagesInProcessing.size();
+        return messagesInProcessing.free();
     }
 
     private void scheduleNewMessageTask(@NonNull Message<I> message,

--- a/src/main/java/com/mercateo/sqs/utils/message/handling/LongRunningMessageHandler.java
+++ b/src/main/java/com/mercateo/sqs/utils/message/handling/LongRunningMessageHandler.java
@@ -56,8 +56,6 @@ public class LongRunningMessageHandler<I, O> {
 
     private final Duration awaitShutDown;
 
-    private final int numberOfThreads;
-
     LongRunningMessageHandler(@NonNull ScheduledExecutorService timeoutExtensionExecutor,
             int maxNumberOfMessages, int numberOfThreads,
             @NonNull MessageHandlingRunnableFactory messageHandlingRunnableFactory,
@@ -80,7 +78,6 @@ public class LongRunningMessageHandler<I, O> {
         this.timeUntilVisibilityTimeoutExtension = timeUntilVisibilityTimeoutExtension;
         this.awaitShutDown = awaitShutDown;
         this.errorHandlingStrategy = errorHandlingStrategy;
-        this.numberOfThreads = numberOfThreads;
 
         messageProcessingExecutor = new ThreadPoolTaskExecutor();
         messageProcessingExecutor.setCorePoolSize(numberOfThreads);

--- a/src/main/java/com/mercateo/sqs/utils/message/handling/SetWithUpperBound.java
+++ b/src/main/java/com/mercateo/sqs/utils/message/handling/SetWithUpperBound.java
@@ -66,7 +66,9 @@ class SetWithUpperBound<T> {
         }
     }
 
-    int size() {
+    int free() {
+        return maximumSize - backingSet.size();
+    }
         return backingSet.size();
     }
 

--- a/src/main/java/com/mercateo/sqs/utils/message/handling/SetWithUpperBound.java
+++ b/src/main/java/com/mercateo/sqs/utils/message/handling/SetWithUpperBound.java
@@ -66,6 +66,10 @@ class SetWithUpperBound<T> {
         }
     }
 
+    int size() {
+        return backingSet.size();
+    }
+
     /**
      * Visible for Testing
      *

--- a/src/main/java/com/mercateo/sqs/utils/message/handling/SetWithUpperBound.java
+++ b/src/main/java/com/mercateo/sqs/utils/message/handling/SetWithUpperBound.java
@@ -69,8 +69,6 @@ class SetWithUpperBound<T> {
     int free() {
         return maximumSize - backingSet.size();
     }
-        return backingSet.size();
-    }
 
     /**
      * Visible for Testing


### PR DESCRIPTION
If we only ever poll messages, for which we know we have free capacity to schedule visibility timeout extensions as well as the actual processing, then we'll never miss the initial/default visibility timeout window. In order to do so, you need to know how many more messages the LongRunningMessageHandler can currently handle. This PR provides that method.

Note that this requires the actual message listener to use make use of this new method, i.e. it won't work with Spring SimpleMessageListenerContainer.